### PR TITLE
Issue #3035541 by chipway: Wrong Dependency prefix in .info.yml

### DIFF
--- a/backerymails.info.yml
+++ b/backerymails.info.yml
@@ -6,6 +6,6 @@ core: 8.x
 
 dependencies:
   - drupal:views
-  - drupal:mailsystem
+  - mailsystem:mailsystem
 
 configure: backerymails.settings


### PR DESCRIPTION
https://www.drupal.org/project/backerymails/issues/3035541